### PR TITLE
feat: 책 추천 기능에 Elasticsearch 도입 및 마이그레이션 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 
     // elasticsearch
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+//    implementation 'co.elastic.clients:elasticsearch-rest-high-level-client:7.17.15'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/hipreader/common/config/ElasticsearchConfig.java
+++ b/src/main/java/com/example/hipreader/common/config/ElasticsearchConfig.java
@@ -1,0 +1,48 @@
+package com.example.hipreader.common.config;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchTemplate;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+
+@Configuration
+public class ElasticsearchConfig extends ElasticsearchConfiguration {
+
+	@Override
+	public ClientConfiguration clientConfiguration() {
+		return ClientConfiguration.builder()
+			.connectedTo("localhost:9200")
+			.build();
+	}
+
+	@Bean
+	public RestClient restClient() {
+		return RestClient.builder(
+				new HttpHost("localhost", 9200, "http"))
+			.build();
+	}
+
+	@Bean
+	public ElasticsearchTransport elasticsearchTransport(RestClient restClient) {
+		return new RestClientTransport(restClient, new JacksonJsonpMapper());
+	}
+
+	@Bean
+	public ElasticsearchClient elasticsearchClient(ElasticsearchTransport transport) {
+		return new ElasticsearchClient(transport);
+	}
+
+	@Bean
+	public ElasticsearchOperations elasticsearchOperations(ElasticsearchTransport transport) {
+		return new ElasticsearchTemplate(elasticsearchClient(transport));
+	}
+}

--- a/src/main/java/com/example/hipreader/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/hipreader/common/config/SecurityConfig.java
@@ -38,6 +38,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests(auth -> auth
 				.requestMatchers("/api/v1/**").permitAll()
 				.requestMatchers("/api/v2/**").permitAll()
+				.requestMatchers("/api/v3/**").permitAll()
 				.anyRequest().authenticated())
 			.formLogin(AbstractHttpConfigurer::disable)
 			.anonymous(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/example/hipreader/common/config/StartupMigrationRunner.java
+++ b/src/main/java/com/example/hipreader/common/config/StartupMigrationRunner.java
@@ -1,0 +1,21 @@
+package com.example.hipreader.common.config;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import com.example.hipreader.domain.userbook.service.UserBookDocumentMigrationService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class StartupMigrationRunner implements ApplicationRunner {
+
+	private final UserBookDocumentMigrationService migrationService;
+
+	@Override
+	public void run(ApplicationArguments args) throws Exception {
+		migrationService.migrate();
+	}
+}

--- a/src/main/java/com/example/hipreader/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/hipreader/common/exception/GlobalExceptionHandler.java
@@ -7,8 +7,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import lombok.extern.slf4j.Slf4j;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler(NotFoundException.class)
@@ -27,7 +29,8 @@ public class GlobalExceptionHandler {
 	}
 
 	@ExceptionHandler(Exception.class)
-	public ResponseEntity<Map<String, Object>> handleGenericException() {
+	public ResponseEntity<Map<String, Object>> handleGenericException(Exception e) {
+		log.info(e.getMessage());
 		return createErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR);
 	}
 

--- a/src/main/java/com/example/hipreader/domain/book/controller/BookRecommendController.java
+++ b/src/main/java/com/example/hipreader/domain/book/controller/BookRecommendController.java
@@ -29,11 +29,11 @@ public class BookRecommendController {
 	public ResponseEntity<PageResponseDto<BookRecommendResponseDto>> recommendBooksWithoutRedis(
 		@RequestParam(required = false) Integer age,
 		@RequestParam(required = false) Gender gender,
-		@RequestParam(required = false) Genre genre,
+		@RequestParam(required = false) String categoryName,
 		@PageableDefault(size = 10, page = 0) Pageable pageable
 	) {
 		PageResponseDto<BookRecommendResponseDto> responseDto = bookRecommendService.recommendBooksWithoutRedis(age,
-			gender, genre, pageable);
+			gender, categoryName, pageable);
 		return new ResponseEntity<>(responseDto, HttpStatus.OK);
 	}
 
@@ -42,11 +42,11 @@ public class BookRecommendController {
 	public ResponseEntity<PageResponseDto<BookRecommendResponseDto>> recommendBooksWithRedis(
 		@RequestParam(required = false) Integer age,
 		@RequestParam(required = false) Gender gender,
-		@RequestParam(required = false) Genre genre,
+		@RequestParam(required = false) String categoryName,
 		@PageableDefault(size = 10, page = 0) Pageable pageable
 	) {
 		PageResponseDto<BookRecommendResponseDto> responseDto = bookRecommendService.recommendBooksWithRedis(age,
-			gender, genre, pageable);
+			gender, categoryName, pageable);
 		return new ResponseEntity<>(responseDto, HttpStatus.OK);
 	}
 }

--- a/src/main/java/com/example/hipreader/domain/book/controller/BookRecommendController.java
+++ b/src/main/java/com/example/hipreader/domain/book/controller/BookRecommendController.java
@@ -49,4 +49,17 @@ public class BookRecommendController {
 			gender, categoryName, pageable);
 		return new ResponseEntity<>(responseDto, HttpStatus.OK);
 	}
+
+	// 연령별, 성별별, 장르별 책 추천 ( Redis + ES )
+	@GetMapping("/v3/books/recommend")
+	public ResponseEntity<PageResponseDto<BookRecommendResponseDto>> recommendBooksWithRedisAndEs(
+		@RequestParam(required = false) Integer age,
+		@RequestParam(required = false) Gender gender,
+		@RequestParam(required = false) String categoryName,
+		@PageableDefault(size = 10, page = 0) Pageable pageable
+	) {
+		PageResponseDto<BookRecommendResponseDto> responseDto = bookRecommendService.recommendBooksWithRedisAndEs(age,
+			gender, categoryName, pageable);
+		return new ResponseEntity<>(responseDto, HttpStatus.OK);
+	}
 }

--- a/src/main/java/com/example/hipreader/domain/book/dto/response/BookRecommendResponseDto.java
+++ b/src/main/java/com/example/hipreader/domain/book/dto/response/BookRecommendResponseDto.java
@@ -2,6 +2,7 @@ package com.example.hipreader.domain.book.dto.response;
 
 import com.example.hipreader.domain.book.entity.Book;
 import com.example.hipreader.domain.book.genre.Genre;
+import com.example.hipreader.domain.userbook.document.UserBookDocument;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,6 +27,16 @@ public class BookRecommendResponseDto {
 			.publisher(book.getPublisher())
 			.coverImage(book.getCoverImage())
 			.categoryName(book.getCategoryName())
+			.build();
+	}
+
+	public static BookRecommendResponseDto toDto(UserBookDocument userBookDocument) {
+		return BookRecommendResponseDto.builder()
+			.title(userBookDocument.getTitle())
+			.author(userBookDocument.getAuthor())
+			.publisher(userBookDocument.getPublisher())
+			.coverImage(userBookDocument.getCoverImage())
+			.categoryName(userBookDocument.getCategoryName())
 			.build();
 	}
 }

--- a/src/main/java/com/example/hipreader/domain/book/service/BookRecommendService.java
+++ b/src/main/java/com/example/hipreader/domain/book/service/BookRecommendService.java
@@ -25,9 +25,10 @@ public class BookRecommendService {
 	private final RedisTemplate<String, Object> redisTemplate;
 
 	// 연령별, 성별별 책 추천 ( MySQL )
-	public PageResponseDto<BookRecommendResponseDto> recommendBooksWithoutRedis(Integer age, Gender gender, Genre genre,
+	public PageResponseDto<BookRecommendResponseDto> recommendBooksWithoutRedis(Integer age, Gender gender,
+		String categoryName,
 		Pageable pageable) {
-		Page<Book> bookPage = userBookRepository.findRecommendedBooks(age, gender, genre, pageable);
+		Page<Book> bookPage = userBookRepository.findRecommendedBooks(age, gender, categoryName, pageable);
 
 		List<BookRecommendResponseDto> content = bookPage.getContent().stream()
 			.map(BookRecommendResponseDto::toDto).toList();
@@ -42,10 +43,12 @@ public class BookRecommendService {
 	}
 
 	// 연령별, 성별별, 장르별 책 추천 ( Redis )
-	public PageResponseDto<BookRecommendResponseDto> recommendBooksWithRedis(Integer age, Gender gender, Genre genre,
+	public PageResponseDto<BookRecommendResponseDto> recommendBooksWithRedis(Integer age, Gender gender,
+		String categoryName,
 		Pageable pageable) {
 
-		String key = String.format("recommend:age=%d:gender=%s:genre=%s:page=%d:size=%d", age, gender, genre.name(),
+		String key = String.format("recommend:age=%d:gender=%s:categoryName=%s:page=%d:size=%d", age, gender,
+			categoryName,
 			pageable.getPageNumber(), pageable.getPageSize());
 
 		// Redis 에서 먼저 캐시 조회
@@ -54,7 +57,7 @@ public class BookRecommendService {
 			return (PageResponseDto<BookRecommendResponseDto>)cached;
 		}
 
-		Page<Book> bookPage = userBookRepository.findRecommendedBooks(age, gender, genre, pageable);
+		Page<Book> bookPage = userBookRepository.findRecommendedBooks(age, gender, categoryName, pageable);
 
 		List<BookRecommendResponseDto> content = bookPage.getContent().stream()
 			.map(BookRecommendResponseDto::toDto).toList();

--- a/src/main/java/com/example/hipreader/domain/userbook/document/UserBookDocument.java
+++ b/src/main/java/com/example/hipreader/domain/userbook/document/UserBookDocument.java
@@ -1,0 +1,44 @@
+package com.example.hipreader.domain.userbook.document;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import com.example.hipreader.domain.user.gender.Gender;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Document(indexName = "userbook")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserBookDocument {
+
+	@Id
+	private String id;
+
+	@Field(type = FieldType.Keyword)
+	private String title;
+
+	@Field(type = FieldType.Keyword)
+	private String author;
+
+	@Field(type = FieldType.Keyword)
+	private String publisher;
+
+	@Field(type = FieldType.Keyword)
+	private String coverImage;
+
+	@Field(type = FieldType.Keyword)
+	private String categoryName;
+
+	@Field(type = FieldType.Keyword)
+	private Gender gender;
+
+	private Integer ageGroup; // 10, 20, 30, 40
+}

--- a/src/main/java/com/example/hipreader/domain/userbook/repository/UserBookRepository.java
+++ b/src/main/java/com/example/hipreader/domain/userbook/repository/UserBookRepository.java
@@ -1,5 +1,7 @@
 package com.example.hipreader.domain.userbook.repository;
 
+import java.util.List;
+
 import com.example.hipreader.domain.book.entity.Book;
 import com.example.hipreader.domain.user.entity.User;
 import com.example.hipreader.domain.userbook.entity.UserBook;
@@ -8,6 +10,7 @@ import com.example.hipreader.domain.userbook.status.Status;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserBookRepository extends JpaRepository<UserBook, Long>, UserBookRepositoryCustom {
 
@@ -19,4 +22,6 @@ public interface UserBookRepository extends JpaRepository<UserBook, Long>, UserB
 
 	Page<UserBook> findByUserAndStatus(User user, Status status, Pageable pageable);
 
+	@Query("SELECT ub FROM UserBook ub JOIN FETCH ub.user JOIN FETCH ub.book")
+	List<UserBook> findAllWithUserAndBook();
 }

--- a/src/main/java/com/example/hipreader/domain/userbook/repository/UserBookRepositoryCustom.java
+++ b/src/main/java/com/example/hipreader/domain/userbook/repository/UserBookRepositoryCustom.java
@@ -10,5 +10,5 @@ import com.example.hipreader.domain.book.genre.Genre;
 import com.example.hipreader.domain.user.gender.Gender;
 
 public interface UserBookRepositoryCustom {
-	Page<Book> findRecommendedBooks(Integer age, Gender gender, Genre Genre, Pageable pageable);
+	Page<Book> findRecommendedBooks(Integer age, Gender gender, String categoryName, Pageable pageable);
 }

--- a/src/main/java/com/example/hipreader/domain/userbook/repository/UserBookRepositoryImpl.java
+++ b/src/main/java/com/example/hipreader/domain/userbook/repository/UserBookRepositoryImpl.java
@@ -25,7 +25,7 @@ public class UserBookRepositoryImpl implements UserBookRepositoryCustom {
 	private final JPAQueryFactory queryFactory;
 
 	@Override
-	public Page<Book> findRecommendedBooks(Integer age, Gender gender, Genre genre, Pageable pageable) {
+	public Page<Book> findRecommendedBooks(Integer age, Gender gender, String categoryName, Pageable pageable) {
 
 		BooleanBuilder builder = new BooleanBuilder();
 
@@ -41,10 +41,10 @@ public class UserBookRepositoryImpl implements UserBookRepositoryCustom {
 			builder.and(user.gender.eq(gender));
 		}
 
-//		// 장르 필터링
-//		if (genre != null) {
-//			builder.and(book.genre.eq(genre));
-//		}
+		// 카테고리 필터링
+		if (categoryName != null) {
+			builder.and(book.categoryName.eq(categoryName));
+		}
 
 		// 컨텐츠 조회
 		List<Book> content = queryFactory

--- a/src/main/java/com/example/hipreader/domain/userbook/service/UserBookDocumentMigrationService.java
+++ b/src/main/java/com/example/hipreader/domain/userbook/service/UserBookDocumentMigrationService.java
@@ -1,0 +1,60 @@
+package com.example.hipreader.domain.userbook.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+import org.springframework.stereotype.Service;
+
+import com.example.hipreader.domain.book.entity.Book;
+import com.example.hipreader.domain.user.entity.User;
+import com.example.hipreader.domain.userbook.document.UserBookDocument;
+import com.example.hipreader.domain.userbook.entity.UserBook;
+import com.example.hipreader.domain.userbook.repository.UserBookRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserBookDocumentMigrationService {
+
+	private final UserBookRepository userBookRepository;
+	private final ElasticsearchOperations elasticsearchOperations;
+
+	public void migrate() {
+		// 1. 기존 인덱스 삭제 후 재생성
+		IndexOperations indexOps = elasticsearchOperations.indexOps(UserBookDocument.class);
+		if (indexOps.exists()) {
+			indexOps.delete();
+		}
+		indexOps.create();
+		indexOps.putMapping();
+
+		// 2. DB 에서 전체 userBook 데이터 조회
+		List<UserBook> userBooks = userBookRepository.findAllWithUserAndBook();
+
+		// 3. document 로 변환 후 저장
+		List<UserBookDocument> userBookDocuments = userBooks.stream()
+			.map(this::convertToDocument)
+			.collect(Collectors.toList());
+
+		elasticsearchOperations.save(userBookDocuments);
+	}
+
+	private UserBookDocument convertToDocument(UserBook userBook) {
+		User user = userBook.getUser();
+		Book book = userBook.getBook();
+
+		return UserBookDocument.builder()
+			.id(user.getId() + "_" + book.getId())
+			.title(book.getTitle())
+			.author(book.getAuthor())
+			.publisher(book.getPublisher())
+			.coverImage(book.getCoverImage())
+			.gender(user.getGender())
+			.categoryName(book.getCategoryName())
+			.ageGroup((user.getAge() / 10) * 10)
+			.build();
+	}
+}

--- a/src/main/java/com/example/hipreader/domain/userbook/service/UserBookSearchService.java
+++ b/src/main/java/com/example/hipreader/domain/userbook/service/UserBookSearchService.java
@@ -1,0 +1,55 @@
+package com.example.hipreader.domain.userbook.service;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.Criteria;
+import org.springframework.data.elasticsearch.core.query.CriteriaQuery;
+import org.springframework.stereotype.Service;
+
+import com.example.hipreader.domain.user.gender.Gender;
+import com.example.hipreader.domain.userbook.document.UserBookDocument;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserBookSearchService {
+
+	private final ElasticsearchOperations elasticsearchOperations;
+
+	public Page<UserBookDocument> searchByCondition(
+		Integer ageGroup,
+		Gender gender,
+		String categoryName,
+		Pageable pageable
+	) {
+		Criteria criteria = new Criteria();
+
+		if (ageGroup != null) {
+			criteria = criteria.and(new Criteria("ageGroup").is(ageGroup));
+		}
+		if (gender != null) {
+			criteria = criteria.and(new Criteria("gender").is(gender.name()));
+		}
+		if (categoryName != null && !categoryName.isBlank()) {
+			criteria = criteria.and(new Criteria("categoryName").is(categoryName));
+		}
+
+		CriteriaQuery query = new CriteriaQuery(criteria, pageable);
+		SearchHits<UserBookDocument> searchHits = elasticsearchOperations.search(query, UserBookDocument.class);
+
+		List<UserBookDocument> content = searchHits.stream()
+			.map(SearchHit::getContent)
+			.toList();
+
+		return new PageImpl<>(content, pageable, searchHits.getTotalHits());
+	}
+}
+


### PR DESCRIPTION
## 🔗 Issue Number
close #41 

## 📝 작업 내역
- [X] 책추천 기능에 Elasticsearch 검색 기능 도입
- [X] 애플리케이션 시작 시 자동 마이그레이션 수행 - 기존 인덱스가 존재하면 삭제, UserBook 에서 조회 후 UserBookDocument 로 변환하여 저장 
- [X] Redis Cache 연동 - 캐시 미스 시 Elasticsearch 에서 데이터 조회, 검색 결과를 Redis 에 저장

## 💡 PR 특이사항
- Elasticsearch 와 Redis 캐시를 함께 사용하여 성능 최적화 
- 검색 조건 동적 적용 (ageGroup, gender, categoryName 중 일부만 입력되어도 검색 가능)

- 현재는 개발/테스트 편의상 애플리케이션 시작 시 인덱스를 삭제 후 재생성하고 전체 마이그레이션을 수행함
- 운영 환경에서는 실시간 동기화 또는 스케줄링 마이그레이션 적용 필요

## 📸 스크린샷
<img width="1013" alt="스크린샷 2025-04-15 오후 4 08 26" src="https://github.com/user-attachments/assets/eaf50da7-1230-4cfa-9717-a9176bbffba0" />
