### PR TITLE
refactor/auth : filter 내 불필요한 메서드 삭제, refreshToken Id값을 토큰으로 변경

### DIFF
--- a/src/main/java/com/example/hipreader/auth/controller/AuthController.java
+++ b/src/main/java/com/example/hipreader/auth/controller/AuthController.java
@@ -14,7 +14,7 @@ import com.example.hipreader.auth.dto.request.SignupRequestDto;
 import com.example.hipreader.auth.dto.response.SigninResponseDto;
 import com.example.hipreader.auth.dto.response.SignupResponseDto;
 import com.example.hipreader.auth.service.AuthService;
-import com.example.hipreader.domain.refreshtoken.service.RefreshTokenService;
+import com.example.hipreader.auth.service.RefreshTokenService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/hipreader/auth/entity/RefreshToken.java
+++ b/src/main/java/com/example/hipreader/auth/entity/RefreshToken.java
@@ -1,4 +1,4 @@
-package com.example.hipreader.domain.refreshtoken.entity;
+package com.example.hipreader.auth.entity;
 
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.index.Indexed;

--- a/src/main/java/com/example/hipreader/auth/entity/RefreshToken.java
+++ b/src/main/java/com/example/hipreader/auth/entity/RefreshToken.java
@@ -1,28 +1,35 @@
 package com.example.hipreader.auth.entity;
 
+import static com.example.hipreader.common.util.JwtUtil.*;
+
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.index.Indexed;
 
 import org.springframework.data.annotation.Id;
+
+import com.example.hipreader.domain.user.entity.User;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 
 @NoArgsConstructor
 @Getter
-@RedisHash(value = "refreshToken") // 7일
+@RedisHash(value = "refreshToken", timeToLive = 14 * 24 * 60 * 60) // 7일
 public class RefreshToken {
 
 	@Id
-	private String id;
-
-	@Indexed
 	private String refreshToken;
 
+	@Indexed
 	private Long userId;
 
-	public RefreshToken(Long userId, String refreshToken) {
-		this.userId = userId;
+	public RefreshToken(String refreshToken, Long userId) {
 		this.refreshToken = refreshToken;
+		this.userId = userId;
+	}
+
+	public static RefreshToken create(String refreshToken, User user) {
+		return new RefreshToken(refreshToken, user.getId());
 	}
 }

--- a/src/main/java/com/example/hipreader/auth/entity/RefreshToken.java
+++ b/src/main/java/com/example/hipreader/auth/entity/RefreshToken.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @Getter
-@RedisHash(value = "refreshToken", timeToLive = 14 * 24 * 60 * 60) // 7일
+@RedisHash(value = "refreshToken", timeToLive = 14 * 24 * 60 * 60) // 14일
 public class RefreshToken {
 
 	@Id

--- a/src/main/java/com/example/hipreader/auth/entity/RefreshToken.java
+++ b/src/main/java/com/example/hipreader/auth/entity/RefreshToken.java
@@ -1,7 +1,5 @@
 package com.example.hipreader.auth.entity;
 
-import static com.example.hipreader.common.util.JwtUtil.*;
-
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.index.Indexed;
 
@@ -27,9 +25,5 @@ public class RefreshToken {
 	public RefreshToken(String refreshToken, Long userId) {
 		this.refreshToken = refreshToken;
 		this.userId = userId;
-	}
-
-	public static RefreshToken create(String refreshToken, User user) {
-		return new RefreshToken(refreshToken, user.getId());
 	}
 }

--- a/src/main/java/com/example/hipreader/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/hipreader/auth/repository/RefreshTokenRepository.java
@@ -1,13 +1,9 @@
 package com.example.hipreader.auth.repository;
 
-import java.util.Optional;
-
 import org.springframework.data.repository.CrudRepository;
 
 import com.example.hipreader.auth.entity.RefreshToken;
 
-public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
-	Optional<RefreshToken> findByRefreshToken(String token);
-
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
 	void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/example/hipreader/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/hipreader/auth/repository/RefreshTokenRepository.java
@@ -1,10 +1,10 @@
-package com.example.hipreader.domain.refreshtoken.repository;
+package com.example.hipreader.auth.repository;
 
 import java.util.Optional;
 
 import org.springframework.data.repository.CrudRepository;
 
-import com.example.hipreader.domain.refreshtoken.entity.RefreshToken;
+import com.example.hipreader.auth.entity.RefreshToken;
 
 public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
 	Optional<RefreshToken> findByRefreshToken(String token);

--- a/src/main/java/com/example/hipreader/auth/service/AuthService.java
+++ b/src/main/java/com/example/hipreader/auth/service/AuthService.java
@@ -62,7 +62,7 @@ public class AuthService {
 		return new SignupResponseDto(accessToken);
 	}
 
-	@Transactional(readOnly = true)
+	@Transactional
 	public SigninResponseDto signIn(@Valid SigninRequestDto signinRequestDto) {
 		User user = userRepository.findByEmail(signinRequestDto.getEmail()).orElseThrow(
 			() -> new NotFoundException(USER_NOT_FOUND));

--- a/src/main/java/com/example/hipreader/auth/service/AuthService.java
+++ b/src/main/java/com/example/hipreader/auth/service/AuthService.java
@@ -5,7 +5,6 @@ import static com.example.hipreader.common.exception.ErrorCode.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.server.ResponseStatusException;
 
 import com.example.hipreader.auth.dto.request.SigninRequestDto;
 import com.example.hipreader.auth.dto.request.SignupRequestDto;
@@ -14,8 +13,8 @@ import com.example.hipreader.auth.dto.response.SignupResponseDto;
 import com.example.hipreader.common.exception.BadRequestException;
 import com.example.hipreader.common.exception.NotFoundException;
 import com.example.hipreader.common.util.JwtUtil;
-import com.example.hipreader.domain.refreshtoken.entity.RefreshToken;
-import com.example.hipreader.domain.refreshtoken.repository.RefreshTokenRepository;
+import com.example.hipreader.auth.entity.RefreshToken;
+import com.example.hipreader.auth.repository.RefreshTokenRepository;
 import com.example.hipreader.domain.user.entity.User;
 import com.example.hipreader.domain.user.gender.Gender;
 import com.example.hipreader.domain.user.repository.UserRepository;

--- a/src/main/java/com/example/hipreader/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/hipreader/auth/service/RefreshTokenService.java
@@ -1,4 +1,4 @@
-package com.example.hipreader.domain.refreshtoken.service;
+package com.example.hipreader.auth.service;
 
 import static com.example.hipreader.common.exception.ErrorCode.*;
 
@@ -6,8 +6,8 @@ import org.springframework.stereotype.Service;
 
 import com.example.hipreader.common.exception.NotFoundException;
 import com.example.hipreader.common.util.JwtUtil;
-import com.example.hipreader.domain.refreshtoken.entity.RefreshToken;
-import com.example.hipreader.domain.refreshtoken.repository.RefreshTokenRepository;
+import com.example.hipreader.auth.entity.RefreshToken;
+import com.example.hipreader.auth.repository.RefreshTokenRepository;
 import com.example.hipreader.domain.user.entity.User;
 import com.example.hipreader.domain.user.repository.UserRepository;
 

--- a/src/main/java/com/example/hipreader/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/hipreader/common/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
 	TOKEN_DUPLICATED("중복된 토큰입니다.", CONFLICT),
 	INVALID_ACCESS_TOKEN("유효하지 않은 AccessToken 입니다.", UNAUTHORIZED),
 	NEED_LOGIN("재로그인이 필요합니다.",UNAUTHORIZED),
+	INVALID_REFRESH_TOKEN("유효하지 않은 REFRESHTOKEN입니다.", UNAUTHORIZED),
 
 	// 리뷰 관련 예외 코드
 	REVIEW_NOT_FOUND("해당 리뷰를 찾을 수 없습니다.", NOT_FOUND),

--- a/src/main/java/com/example/hipreader/domain/book/dto/response/BookRecommendResponseDto.java
+++ b/src/main/java/com/example/hipreader/domain/book/dto/response/BookRecommendResponseDto.java
@@ -2,7 +2,6 @@ package com.example.hipreader.domain.book.dto.response;
 
 import com.example.hipreader.domain.book.entity.Author;
 import com.example.hipreader.domain.book.entity.Book;
-import com.example.hipreader.domain.book.genre.Genre;
 import com.example.hipreader.domain.userbook.document.UserBookDocument;
 
 import java.util.stream.Collectors;

--- a/src/main/java/com/example/hipreader/domain/bookscore/batch/BookScoreInitializer.java
+++ b/src/main/java/com/example/hipreader/domain/bookscore/batch/BookScoreInitializer.java
@@ -3,6 +3,7 @@ package com.example.hipreader.domain.bookscore.batch;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.hipreader.domain.book.entity.Book;
 import com.example.hipreader.domain.bookscore.entity.BookScore;
 import com.example.hipreader.domain.bookscore.repository.BookScoreRepository;
 
@@ -23,9 +24,10 @@ public class BookScoreInitializer {
 	@Transactional
 	public void init() {
 		userBookRepository.findAll().forEach(ub -> {
-			BookScore score = bookScoreRepository.findById(ub.getBook().getId())
+			Book book = ub.getBook(); // UserBook에서 Book 객체 직접 참조
+			BookScore score = bookScoreRepository.findByBook(book)
 				.orElseGet(() -> BookScore.builder()
-					.bookId(ub.getBook().getId())
+					.book(book) // Book 객체로 생성
 					.build());
 
 			score.increment(ub.getStatus());

--- a/src/main/java/com/example/hipreader/domain/bookscore/dto/response/GetBookOfYearResponseDto.java
+++ b/src/main/java/com/example/hipreader/domain/bookscore/dto/response/GetBookOfYearResponseDto.java
@@ -17,7 +17,7 @@ public class GetBookOfYearResponseDto {
 	@Min(0)
 	private final long totalScore;
 
-	public static GetBookOfYearResponseDto from(Book book, long totalScore) {
+	public static GetBookOfYearResponseDto toDto(Book book, long totalScore) {
 		return builder()
 			.title(book.getTitle())
 			.author(book.getAuthor())

--- a/src/main/java/com/example/hipreader/domain/bookscore/entity/YearlyBookScore.java
+++ b/src/main/java/com/example/hipreader/domain/bookscore/entity/YearlyBookScore.java
@@ -1,7 +1,6 @@
 package com.example.hipreader.domain.bookscore.entity;
 
 import com.example.hipreader.domain.book.entity.Book;
-import com.example.hipreader.domain.userbook.status.Status;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -12,60 +11,34 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "book_scores")
+@Table(name = "yearly_book_scores")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class BookScore {
+public class YearlyBookScore {
 
 	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
+
+	@Column(nullable = false)
+	private int year;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "book_id", nullable = false)
 	private Book book;
 
 	@Column(nullable = false)
-	private long toRead = 0L;
+	private long totalScore;
 
-	@Column(nullable = false)
-	private long reading = 0L;
-
-	@Column(nullable = false)
-	private long finished = 0L;
-
-	@Transient
-	public long getTotalScore() {
-		return toRead + reading * 2 + finished * 3;
+	public void updateTopBook(Book book, long totalScore) {
+		this.book = book;
+		this.totalScore = totalScore;
 	}
-
-	public void updateCount(Status oldStatus, Status newStatus) {
-		if (oldStatus != null) decrement(oldStatus);
-		increment(newStatus);
-	}
-
-	public void decrement(Status status) {
-		switch (status) {
-			case TO_READ -> toRead--;
-			case READING -> reading--;
-			case FINISHED -> finished--;
-		}
-	}
-
-	public void increment(Status status) {
-		switch (status) {
-			case TO_READ -> toRead++;
-			case READING -> reading++;
-			case FINISHED -> finished++;
-		}
-	}
-
 }

--- a/src/main/java/com/example/hipreader/domain/bookscore/repository/BookScoreRepository.java
+++ b/src/main/java/com/example/hipreader/domain/bookscore/repository/BookScoreRepository.java
@@ -1,8 +1,14 @@
 package com.example.hipreader.domain.bookscore.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.example.hipreader.domain.book.entity.Book;
 import com.example.hipreader.domain.bookscore.entity.BookScore;
 
 public interface BookScoreRepository extends JpaRepository<BookScore, Long> {
+	@Query("SELECT bs FROM BookScore bs WHERE bs.book = :book")
+	Optional<BookScore> findByBook(Book book);
 }

--- a/src/main/java/com/example/hipreader/domain/bookscore/repository/YearlyBookScoreRepository.java
+++ b/src/main/java/com/example/hipreader/domain/bookscore/repository/YearlyBookScoreRepository.java
@@ -1,0 +1,13 @@
+package com.example.hipreader.domain.bookscore.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.example.hipreader.domain.bookscore.entity.YearlyBookScore;
+
+public interface YearlyBookScoreRepository extends JpaRepository<YearlyBookScore, Long> {
+	@Query("SELECT y FROM YearlyBookScore y JOIN FETCH y.book WHERE y.year = :year")
+	Optional<YearlyBookScore> findByYear(int year);
+}

--- a/src/main/java/com/example/hipreader/domain/bookscore/service/BookScoreService.java
+++ b/src/main/java/com/example/hipreader/domain/bookscore/service/BookScoreService.java
@@ -69,7 +69,7 @@ public class BookScoreService {
 		YearlyBookScore yearlyTopBook = yearlyBookScoreRepository.findByYear(currentYear)
 			.orElseThrow(() -> new NotFoundException(BOOK_NOT_PUBLISHED));
 
-		return GetBookOfYearResponseDto.toDto(
+		return GetBookOfYearResponseDto.from(
 			yearlyTopBook.getBook(),
 			yearlyTopBook.getTotalScore()
 		);

--- a/src/main/java/com/example/hipreader/domain/bookscore/service/BookScoreService.java
+++ b/src/main/java/com/example/hipreader/domain/bookscore/service/BookScoreService.java
@@ -3,8 +3,6 @@ package com.example.hipreader.domain.bookscore.service;
 import static com.example.hipreader.common.exception.ErrorCode.*;
 
 import java.time.LocalDate;
-import java.util.Comparator;
-import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/example/hipreader/domain/bookscore/service/BookScoreService.java
+++ b/src/main/java/com/example/hipreader/domain/bookscore/service/BookScoreService.java
@@ -14,7 +14,9 @@ import com.example.hipreader.domain.book.entity.Book;
 import com.example.hipreader.domain.book.repository.BookRepository;
 import com.example.hipreader.domain.bookscore.dto.response.GetBookOfYearResponseDto;
 import com.example.hipreader.domain.bookscore.entity.BookScore;
+import com.example.hipreader.domain.bookscore.entity.YearlyBookScore;
 import com.example.hipreader.domain.bookscore.repository.BookScoreRepository;
+import com.example.hipreader.domain.bookscore.repository.YearlyBookScoreRepository;
 import com.example.hipreader.domain.userbook.status.Status;
 
 import lombok.RequiredArgsConstructor;
@@ -25,44 +27,51 @@ public class BookScoreService {
 
 	private final BookRepository bookRepository;
 	private final BookScoreRepository bookScoreRepository;
+	private final YearlyBookScoreRepository yearlyBookScoreRepository;
 
 	@Transactional
 	public void handleStatusChange(Long bookId, Status oldStatus, Status newStatus) {
-		BookScore score = bookScoreRepository.findById(bookId)
-			.orElseGet(() -> BookScore.builder().bookId(bookId).build());
+		Book book = bookRepository.findById(bookId)
+			.orElseThrow(() -> new NotFoundException(BOOK_NOT_FOUND));
+
+		BookScore score = bookScoreRepository.findByBook(book)
+			.orElseGet(() -> BookScore.builder().book(book).build());
 
 		score.updateCount(oldStatus, newStatus);
 		bookScoreRepository.save(score);
+
+		// 올해 출간된 책인지 확인 후 YearlyBookScore 업데이트
+		LocalDate now = LocalDate.now();
+		int currentYear = now.getYear();
+
+		if (book.getDatePublished().getYear() == currentYear) {
+			long totalScore = score.getTotalScore();
+
+			YearlyBookScore yearlyTopBook = yearlyBookScoreRepository.findByYear(currentYear)
+				.orElseGet(() -> YearlyBookScore.builder()
+					.year(currentYear)
+					.book(book)
+					.totalScore(totalScore)
+					.build());
+
+			if (totalScore > yearlyTopBook.getTotalScore()) {
+				yearlyTopBook.updateTopBook(book, totalScore);
+			}
+
+			yearlyBookScoreRepository.save(yearlyTopBook);
+		}
 	}
 
 	@Transactional(readOnly = true)
 	public GetBookOfYearResponseDto getBookOfTheYear() {
-		// 1. 올해 출판된 책 조회
-		LocalDate start = LocalDate.now().withDayOfYear(1); // 올해 첫날
-		LocalDate end = LocalDate.now().withDayOfYear(LocalDate.now().lengthOfYear()); // 올해 마지막 날
-		List<Book> currentYearBooks = bookRepository.findBooksByPublicationYear(start, end);
+		int currentYear = LocalDate.now().getYear();
 
-		if (currentYearBooks.isEmpty()) {
-			throw new NotFoundException(BOOK_NOT_PUBLISHED);
-		}
+		YearlyBookScore yearlyTopBook = yearlyBookScoreRepository.findByYear(currentYear)
+			.orElseThrow(() -> new NotFoundException(BOOK_NOT_PUBLISHED));
 
-		// 2. 해당 책들의 점수 조회
-		List<BookScore> scores = bookScoreRepository.findAllById(
-			currentYearBooks.stream()
-				.map(Book::getId)
-				.toList()
+		return GetBookOfYearResponseDto.toDto(
+			yearlyTopBook.getBook(),
+			yearlyTopBook.getTotalScore()
 		);
-
-		// 3. 최고 점수 책 찾기
-		BookScore topScore = scores.stream()
-			.max(Comparator.comparingLong(BookScore::getTotalScore))
-			.orElseThrow(() -> new NotFoundException(SCORE_NOT_FOUND));
-
-		// 4. 최고 점수 책 정보 가져오기
-		Book topBook = bookRepository.findById(topScore.getBookId())
-			.orElseThrow(() -> new NotFoundException(BOOK_NOT_FOUND));
-
-		// 5. DTO 변환 (from 메서드 사용)
-		return GetBookOfYearResponseDto.from(topBook, topScore.getTotalScore());
 	}
 }

--- a/src/main/java/com/example/hipreader/domain/review/entity/Review.java
+++ b/src/main/java/com/example/hipreader/domain/review/entity/Review.java
@@ -27,9 +27,7 @@ public class Review extends TimeStamped {
 
 	@Column
 	private String content;
-
-	@Min(1)
-	@Max(5)
+	
 	private Integer rating;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/hipreader/domain/user/service/UserService.java
+++ b/src/main/java/com/example/hipreader/domain/user/service/UserService.java
@@ -38,6 +38,7 @@ public class UserService {
 		return GetUserResponseDto.toDto(user);
 	}
 
+	@Transactional
 	public UpdateUserResponseDto updateUser(AuthUser authUser, UpdateUserRequestDto updateUserRequestDto) {
 		User user = userRepository.findUserById(authUser.getId())
 			.orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
@@ -64,14 +65,6 @@ public class UserService {
 		user.changePassword(passwordEncoder.encode(changePasswordRequestDto.getNewPassword()));
 	}
 
-	private static void validateNewPassword(ChangePasswordRequestDto changePasswordRequestDto) {
-		if (changePasswordRequestDto.getNewPassword().length() < 8 ||
-			!changePasswordRequestDto.getNewPassword().matches(".*\\d.*") ||
-			!changePasswordRequestDto.getNewPassword().matches(".*[A-Z].*")) {
-			throw new BadRequestException(INVALID_NEW_PASSWORD_FORMAT);
-		}
-	}
-
 	@Transactional
 	public void deleteUser(AuthUser authUser, DeleteUserRequestDto request) {
 		User findUser = userRepository.findUserById(authUser.getId())
@@ -84,6 +77,7 @@ public class UserService {
 		findUser.deleteUser();
 	}
 
+	@Transactional(readOnly = true)
 	public Page<GetUserResponseDto> getUsers(int page, int size) {
 
 		PageRequest pageRequest = PageRequest.of(Math.max(0, page-1), size, Sort.by(Sort.Direction.DESC, "updatedAt"));
@@ -91,6 +85,14 @@ public class UserService {
 		return userRepository.findAll(pageRequest)
 			.map(user -> new GetUserResponseDto(user.getId(), user.getEmail()));
 		//성능 최적화 시 쿼리문으로 필요한 정보만 가져오게 select문 수정가능.
+		//또는 프로젝션
 	}
 
+	private static void validateNewPassword(ChangePasswordRequestDto changePasswordRequestDto) {
+		if (changePasswordRequestDto.getNewPassword().length() < 8 ||
+			!changePasswordRequestDto.getNewPassword().matches(".*\\d.*") ||
+			!changePasswordRequestDto.getNewPassword().matches(".*[A-Z].*")) {
+			throw new BadRequestException(INVALID_NEW_PASSWORD_FORMAT);
+		}
+	}
 }

--- a/src/main/java/com/example/hipreader/domain/userbook/dto/response/GetUserBookResponseDto.java
+++ b/src/main/java/com/example/hipreader/domain/userbook/dto/response/GetUserBookResponseDto.java
@@ -4,7 +4,6 @@ import com.example.hipreader.domain.book.entity.Author;
 import com.example.hipreader.domain.book.entity.Book;
 import com.example.hipreader.domain.userbook.entity.UserBook;
 import com.example.hipreader.domain.userbook.status.Status;
-import com.example.hipreader.domain.user.entity.User;
 
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/example/hipreader/domain/userbook/dto/response/UpdateUserBookResponseDto.java
+++ b/src/main/java/com/example/hipreader/domain/userbook/dto/response/UpdateUserBookResponseDto.java
@@ -2,7 +2,6 @@ package com.example.hipreader.domain.userbook.dto.response;
 
 import com.example.hipreader.domain.book.entity.Author;
 import com.example.hipreader.domain.book.entity.Book;
-import com.example.hipreader.domain.user.entity.User;
 import com.example.hipreader.domain.userbook.entity.UserBook;
 import com.example.hipreader.domain.userbook.status.Status;
 

--- a/src/test/java/com/example/hipreader/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/hipreader/auth/service/AuthServiceTest.java
@@ -18,7 +18,7 @@ import com.example.hipreader.auth.dto.request.SigninRequestDto;
 import com.example.hipreader.auth.dto.request.SignupRequestDto;
 import com.example.hipreader.auth.dto.response.SigninResponseDto;
 import com.example.hipreader.common.util.JwtUtil;
-import com.example.hipreader.domain.refreshtoken.repository.RefreshTokenRepository;
+import com.example.hipreader.auth.repository.RefreshTokenRepository;
 import com.example.hipreader.domain.user.entity.User;
 import com.example.hipreader.domain.user.repository.UserRepository;
 import com.example.hipreader.domain.user.role.UserRole;


### PR DESCRIPTION
## 🔗 Issue Number


## 📝 작업 내역
- [X] filter 내 불필요한 메서드 삭제
- [X] refreshtoken entitiy key값을 Token으로 변경
- [X] 엔티티 변경에 따른 다른 로직들 수정


## 💡 PR 특이사항
액세스 토큰 유효기간 1시간으로 바뀌었습니다


## 📸 스크린샷
회원가입 성공
![image](https://github.com/user-attachments/assets/070b0810-e14b-4533-a2bf-fc44b55a7cb3)
로그인 성공
![image](https://github.com/user-attachments/assets/bdb9d00c-040e-4f51-938a-f9d3b1ceeb3a)
리프레쉬 성공
![image](https://github.com/user-attachments/assets/aad9bf31-0fd5-4214-98fd-881e3d8b387d)



