### PR TITLE
fix:auth 비밀번호 찾기 기능구현, 403 Forbidden 외  잘못된 오류코드 출력 이슈 해결

### DIFF
--- a/src/main/java/com/example/hipreader/auth/controller/AuthController.java
+++ b/src/main/java/com/example/hipreader/auth/controller/AuthController.java
@@ -6,9 +6,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.hipreader.auth.dto.request.ForgotPasswordRequestDto;
 import com.example.hipreader.auth.dto.request.RefreshTokenRequestDto;
+import com.example.hipreader.auth.dto.request.ResetPasswordRequestDto;
 import com.example.hipreader.auth.dto.request.SigninRequestDto;
 import com.example.hipreader.auth.dto.request.SignupRequestDto;
 import com.example.hipreader.auth.dto.response.SigninResponseDto;
@@ -66,6 +69,21 @@ public class AuthController {
 		headers.set("Authorization", newAccessToken);
 
 		return new ResponseEntity<>(headers, HttpStatus.CREATED);
+	}
+
+	@PostMapping("/v1/auth/forgot-password")
+	public ResponseEntity<Void> forgotPassword(
+		@RequestBody @Valid ForgotPasswordRequestDto forgotPasswordRequestDto) {
+		authService.requestPasswordReset(forgotPasswordRequestDto);
+		return new ResponseEntity<>(HttpStatus.OK);
+	}
+
+	@PostMapping("/v1/auth/reset-password")
+	public ResponseEntity<Void> resetPassword(
+		@RequestBody @Valid ResetPasswordRequestDto resetPasswordRequestDto
+	) {
+		authService.resetPassword(resetPasswordRequestDto);
+		return new ResponseEntity<>(HttpStatus.OK);
 	}
 
 }

--- a/src/main/java/com/example/hipreader/auth/controller/AuthController.java
+++ b/src/main/java/com/example/hipreader/auth/controller/AuthController.java
@@ -6,7 +6,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.example.hipreader.auth.dto.request.ForgotPasswordRequestDto;

--- a/src/main/java/com/example/hipreader/auth/dto/request/ForgotPasswordRequestDto.java
+++ b/src/main/java/com/example/hipreader/auth/dto/request/ForgotPasswordRequestDto.java
@@ -1,0 +1,12 @@
+package com.example.hipreader.auth.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ForgotPasswordRequestDto {
+	private String email;
+}

--- a/src/main/java/com/example/hipreader/auth/dto/request/ResetPasswordRequestDto.java
+++ b/src/main/java/com/example/hipreader/auth/dto/request/ResetPasswordRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.hipreader.auth.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResetPasswordRequestDto {
+	private String token;
+	private String newPassword;
+}

--- a/src/main/java/com/example/hipreader/auth/entity/PasswordResetToken.java
+++ b/src/main/java/com/example/hipreader/auth/entity/PasswordResetToken.java
@@ -1,0 +1,43 @@
+package com.example.hipreader.auth.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PasswordResetToken {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, unique = true)
+	private String token; // UUID
+
+	@Column(nullable = false)
+	private LocalDateTime expiryDate;
+
+	@Column(nullable = false)
+	private String email; // User.email과 연결
+
+	@Builder
+	public PasswordResetToken(String email, String token) {
+		this.email = email;
+		this.token = token;
+		this.expiryDate = LocalDateTime.now().plusHours(1);
+	}
+
+	public boolean isExpired() {
+		return LocalDateTime.now().isAfter(expiryDate);
+	}
+}

--- a/src/main/java/com/example/hipreader/auth/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/com/example/hipreader/auth/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,12 @@
+package com.example.hipreader.auth.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.hipreader.auth.entity.PasswordResetToken;
+
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+	Optional<PasswordResetToken> findByToken(String token);
+	void deleteByEmail(String email);
+}

--- a/src/main/java/com/example/hipreader/auth/service/AuthService.java
+++ b/src/main/java/com/example/hipreader/auth/service/AuthService.java
@@ -2,17 +2,24 @@ package com.example.hipreader.auth.service;
 
 import static com.example.hipreader.common.exception.ErrorCode.*;
 
+import java.util.UUID;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.example.hipreader.auth.dto.request.ForgotPasswordRequestDto;
+import com.example.hipreader.auth.dto.request.ResetPasswordRequestDto;
 import com.example.hipreader.auth.dto.request.SigninRequestDto;
 import com.example.hipreader.auth.dto.request.SignupRequestDto;
 import com.example.hipreader.auth.dto.response.SigninResponseDto;
 import com.example.hipreader.auth.dto.response.SignupResponseDto;
+import com.example.hipreader.auth.entity.PasswordResetToken;
+import com.example.hipreader.auth.repository.PasswordResetTokenRepository;
 import com.example.hipreader.common.exception.BadRequestException;
 import com.example.hipreader.common.exception.ConflictException;
 import com.example.hipreader.common.exception.NotFoundException;
+import com.example.hipreader.common.exception.UnauthorizedException;
 import com.example.hipreader.common.util.JwtUtil;
 import com.example.hipreader.auth.entity.RefreshToken;
 import com.example.hipreader.auth.repository.RefreshTokenRepository;
@@ -20,6 +27,7 @@ import com.example.hipreader.domain.user.entity.User;
 import com.example.hipreader.domain.user.vo.Gender;
 import com.example.hipreader.domain.user.repository.UserRepository;
 import com.example.hipreader.domain.user.vo.UserRole;
+import com.example.hipreader.domain.userdiscussion.service.EmailService;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +40,8 @@ public class AuthService {
 	private final PasswordEncoder passwordEncoder;
 	private final JwtUtil jwtUtil;
 	private final RefreshTokenRepository refreshTokenRepository;
+	private final PasswordResetTokenRepository passwordResetTokenRepository;
+	private final EmailService emailService;
 
 	@Transactional
 	public SignupResponseDto signUp(
@@ -89,4 +99,32 @@ public class AuthService {
 		return new SigninResponseDto(accessToken, refreshToken, user.getNickname());
 	}
 
+	public void requestPasswordReset(ForgotPasswordRequestDto forgotPasswordRequestDto) {
+		User user = userRepository.findByEmail(forgotPasswordRequestDto.getEmail())
+			.orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+
+		passwordResetTokenRepository.deleteByEmail(forgotPasswordRequestDto.getEmail()); // 기존 토큰 삭제
+
+		String token = UUID.randomUUID().toString();
+		passwordResetTokenRepository.save(new PasswordResetToken(forgotPasswordRequestDto.getEmail(), token));
+
+		emailService.sendPasswordResetEmail(forgotPasswordRequestDto.getEmail(), token);
+	}
+
+	@Transactional
+	public void resetPassword(ResetPasswordRequestDto resetPasswordRequestDto) {
+		PasswordResetToken resetToken = passwordResetTokenRepository.findByToken(resetPasswordRequestDto.getToken())
+			.orElseThrow(() -> new NotFoundException(TOKEN_NOT_FOUND));
+
+		if (resetToken.isExpired()) {
+			throw new UnauthorizedException(EXPIRED_TOKEN);
+		}
+
+		User user = userRepository.findByEmail(resetToken.getEmail())
+			.orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
+
+		user.changePassword(passwordEncoder.encode(resetPasswordRequestDto.getNewPassword())); // 중요: 암호화 필수
+		userRepository.save(user);
+		passwordResetTokenRepository.delete(resetToken);
+	}
 }

--- a/src/main/java/com/example/hipreader/auth/service/AuthService.java
+++ b/src/main/java/com/example/hipreader/auth/service/AuthService.java
@@ -99,16 +99,17 @@ public class AuthService {
 		return new SigninResponseDto(accessToken, refreshToken, user.getNickname());
 	}
 
+	@Transactional
 	public void requestPasswordReset(ForgotPasswordRequestDto forgotPasswordRequestDto) {
 		User user = userRepository.findByEmail(forgotPasswordRequestDto.getEmail())
 			.orElseThrow(() -> new NotFoundException(USER_NOT_FOUND));
 
-		passwordResetTokenRepository.deleteByEmail(forgotPasswordRequestDto.getEmail()); // 기존 토큰 삭제
+		passwordResetTokenRepository.deleteByEmail(user.getEmail()); // 기존 토큰 삭제
 
 		String token = UUID.randomUUID().toString();
-		passwordResetTokenRepository.save(new PasswordResetToken(forgotPasswordRequestDto.getEmail(), token));
+		passwordResetTokenRepository.save(new PasswordResetToken(user.getEmail(), token));
 
-		emailService.sendPasswordResetEmail(forgotPasswordRequestDto.getEmail(), token);
+		emailService.sendPasswordResetEmail(user.getEmail(), token);//이메일 발송은 외부 트랜잭션에서 하는게 좋다..
 	}
 
 	@Transactional

--- a/src/main/java/com/example/hipreader/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/hipreader/common/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
 			.sessionManagement(session -> session
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
-				.requestMatchers("/api/v1/**").permitAll()
+				.requestMatchers("/api/v1/**","/error").permitAll()
 				.requestMatchers("/api/v2/**").permitAll()
 				.requestMatchers("/api/v3/**").permitAll()
 				.requestMatchers("/swagger-ui/**").permitAll()

--- a/src/main/java/com/example/hipreader/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/hipreader/common/exception/GlobalExceptionHandler.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import lombok.extern.slf4j.Slf4j;
 
-@RestControllerAdvice(basePackages = "com.example.hipreader.api")
+@RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
 

--- a/src/main/java/com/example/hipreader/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/hipreader/common/filter/JwtAuthenticationFilter.java
@@ -10,6 +10,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.example.hipreader.auth.dto.AuthUser;
 import com.example.hipreader.common.config.JwtAuthenticationToken;
+import com.example.hipreader.common.exception.ErrorCode;
 import com.example.hipreader.common.exception.UnauthorizedException;
 import com.example.hipreader.common.util.JwtUtil;
 import com.example.hipreader.domain.user.vo.UserRole;
@@ -41,24 +42,23 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
 		String authorizationHeader = request.getHeader("Authorization");
 
-		if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
-			String token = jwtUtil.substringToken(authorizationHeader);
-			try {
+		try {
+			if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+				String token = jwtUtil.substringToken(authorizationHeader);
 				Claims claims = jwtUtil.extractClaims(token);
 				setAuthentication(claims);
-
-			} catch (ExpiredJwtException e) {
-				log.error("만료된 JWT token 입니다.", e);
-				throw new UnauthorizedException(NEED_LOGIN);
-			} catch (JwtException e) {
-				log.error("유효하지 않는 Access Token 입니다.", e);
-				throw new UnauthorizedException(INVALID_ACCESS_TOKEN);
-			} catch (Exception e) {
-				log.error("Internal server error", e);
-				response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 			}
+			filterChain.doFilter(request, response);
+		} catch (ExpiredJwtException e) {
+			log.error("만료된 JWT token 입니다.", e);
+			handleException(response, NEED_LOGIN);
+		} catch (JwtException | IllegalArgumentException e) {
+			log.error("유효하지 않은 Access Token 입니다.", e);
+			handleException(response, INVALID_ACCESS_TOKEN);
+		} catch (Exception e) {
+			log.error("Internal server error", e);
+			handleException(response, INTERNAL_SERVER_ERROR);
 		}
-		filterChain.doFilter(request, response);
 	}
 
 	private void setAuthentication(Claims claims) {
@@ -70,5 +70,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		JwtAuthenticationToken authenticationToken = new JwtAuthenticationToken(authUser);
 
 		SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+	}
+
+	private void handleException(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+		SecurityContextHolder.clearContext(); // SecurityContext 초기화
+		response.sendError(errorCode.getStatus().value(), errorCode.getMessage());
 	}
 }

--- a/src/main/java/com/example/hipreader/domain/user/entity/User.java
+++ b/src/main/java/com/example/hipreader/domain/user/entity/User.java
@@ -54,8 +54,8 @@ public class User extends TimeStamped {
 		if (gender != null) this.gender = gender;
 	}
 
-	public void changePassword(String password) {
-		this.password = password;
+	public void changePassword(String encodedPassword) {
+		this.password = encodedPassword;
 	}
 
 	public void deleteUser() {

--- a/src/main/java/com/example/hipreader/domain/userdiscussion/service/EmailService.java
+++ b/src/main/java/com/example/hipreader/domain/userdiscussion/service/EmailService.java
@@ -42,4 +42,15 @@ public class EmailService {
 			throw new RuntimeException("메일 전송 실패", e);
 		}
 	}
+
+	public void sendPasswordResetEmail(String email, String token) {
+		Context context = new Context();
+		context.setVariable("token", token);
+		sendHtmlEmail(
+			email,
+			"[HipReader] 비밀번호 재설정 안내",
+			"email/password-reset",
+			context
+		);
+	}
 }

--- a/src/main/resources/templates/email/password-reset.html
+++ b/src/main/resources/templates/email/password-reset.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>비밀번호 재설정 안내</title>
+</head>
+<body>
+<h1>HipReader 비밀번호 재설정</h1>
+<p>아래 버튼을 클릭하여 비밀번호를 재설정해주세요.</p>
+<a th:href="@{https://hipreader.com/reset-password(token=${token})}"
+   style="background-color: #4CAF50; color: white; padding: 14px 25px; text-align: center; text-decoration: none; display: inline-block;">
+    비밀번호 재설정
+</a>
+<p>※ 이 링크는 1시간 동안 유효합니다.</p>
+</body>
+</html>


### PR DESCRIPTION
## 🔗 Issue Number
 <!--- close #이슈번호 -->
#82 

## 📝 작업 내역
 <!--- 구현 내용 및 변경 사항, 관련 이슈에 대해 간단하게 작성해주세요.-->
- [X] 비밀번호 찾기 기능 구현
- [X] 잘못된 에러 코드 나는거 수정


## 💡 PR 특이사항
 <!--- PR을 볼 때 팀원에게 알려야 할 특이사항, 논의해야할 부분 등을 알려주세요.-->
이슈번호에서 비밀번호 재설정이 어떻게 동작하는지 설명했습니다. 더 궁금한 점 있으면 공유부탁드립니다.

## 📸 스크린샷
 <!---선택 사항입니다. 사용하지 않으면 삭제해주세요.-->
403오류뜬거 해결-> 500오류가뜸 -> 해결-> 정상오류코드 뜨도록 반환하였습니다.
기존에 403Forbidden뜨던것이 이제 정상적으로 409 에러 반환하도록 수정되었습니다.
아래는 테스트코드 사진입니다. 
![image](https://github.com/user-attachments/assets/cc1a8957-39ff-4b25-9170-7c367ed71212)
